### PR TITLE
TECH enable comma-dangle multilines rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
     'no-param-reassign': 0,
     'valid-jsdoc': 1,
     'require-jsdoc': 1,
-    'comma-dangle': [2, 'never'],
+    'comma-dangle': [1, 'always-multiline'],
     'no-underscore-dangle': [0],
     'newline-per-chained-call': [0],
     'import/no-extraneous-dependencies': [2, { devDependencies: true }],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-cp",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "The Chauffeur-Privé ESLint",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
comma-dangle rule was disabled. 
As discussed during the platform architecture meeting we will enable it because it provides 2 advantages:
- Github won't mark the previous line as diff when we add/remove an element/attribute from an array/object.
- Copy/Paste or remove element/attribute without having to think about the comma.

See https://eslint.org/docs/rules/comma-dangle#always-multiline for more info