### PR TITLE
Tech object curly newline to consistent

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,10 +29,6 @@ module.exports = {
     ],
     'require-await': 2
   },
-  ecmaFeatures: {
-    generators: true,
-    impliedStrict: true
-  },
   globals: {
     describe: true,
     it: true,

--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ module.exports = {
     'import/no-extraneous-dependencies': [2, { devDependencies: true }],
     strict: [2, 'global'],
     'arrow-parens': [0],
+    'object-curly-newline': [2,
+      { 'consistent': true }
+    ],
     'no-restricted-syntax': [
       'error',
       'ForInStatement',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-cp",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "The Chauffeur-Privé ESLint",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Removed ecmaFeature because of deprecation warning
- Added object-curly-newline consistent true rule
```
function foo({ a, b, c}) {
    // some stuff
}
```
caused linting error and required to be broken to the line. 
Consistent requires that if there is a line break, then the other curly brace be put on a new line as well. 